### PR TITLE
chore: automerge minor and patch dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,9 +30,8 @@
       "matchPackageNames": ["vitest", "happy-dom"]
     },
     {
-      "description": "Automerge patch updates for dev dependencies",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch"],
+      "description": "Automerge minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
Broadens the Renovate automerge rule to include both minor and patch updates for all dependencies (not just patch updates for devDependencies). Minor version bumps follow semver and shouldn't contain breaking changes, so they're safe to automerge.