### PR TITLE
fix: use pageParam in useInternalInfiniteQuery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -510,8 +510,8 @@ export function useInternalInfiniteQuery<TQueryFnData>(
       key: queryKey,
       initialPageParam: toValue(argsValue),
       ...optionsValue,
-      query: ({ signal }: any) => {
-        const reqUrl = makeUrl(endpoint, model, operation, argsValue)
+      query: ({ signal, pageParam }: any) => {
+        const reqUrl = makeUrl(endpoint, model, operation, pageParam ?? argsValue)
         return fetcher<TQueryFnData>(reqUrl, { signal }, fetch)
       },
     }


### PR DESCRIPTION
## Summary

`useInternalInfiniteQuery` ignored the `pageParam` provided by `@pinia/colada`'s `useInfiniteQuery`, causing every page fetch to use identical args. Now uses `pageParam` when available, falling back to `argsValue` for the initial page.

Closes #95