### PR TITLE
fix: resolve useInfiniteFindMany crash with @pinia/colada >= 1.2.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -502,7 +502,7 @@ export function useInternalInfiniteQuery<TQueryFnData>(
     return getQueryKey(model, operation, argsValue, { infinite: true, optimisticUpdate: false })
   }
 
-  const finalOptions = () => {
+  const finalOptions: any = () => {
     const argsValue = toValue(args)
     const optionsValue = toValue(options)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -502,7 +502,7 @@ export function useInternalInfiniteQuery<TQueryFnData>(
     return getQueryKey(model, operation, argsValue, { infinite: true, optimisticUpdate: false })
   }
 
-  const finalOptions: any = computed(() => {
+  const finalOptions = () => {
     const argsValue = toValue(args)
     const optionsValue = toValue(options)
 
@@ -515,7 +515,7 @@ export function useInternalInfiniteQuery<TQueryFnData>(
         return fetcher<TQueryFnData>(reqUrl, { signal }, fetch)
       },
     }
-  })
+  }
 
   return {
     queryKey,


### PR DESCRIPTION
## Summary

- Fixes `TypeError: opts.query is not a function` when using `useInfiniteFindMany` with `@pinia/colada@1.2.0+`
- Root cause: colada 1.2.0 switched from `toValue()` to `toValueWithArgs()` which only unwraps functions, not `ComputedRef`
- Changed `useInternalInfiniteQuery`'s `finalOptions` from `computed(() => ...)` to a plain arrow function

Closes #102

## Test plan

- [ ] Verify `useInfiniteFindMany` works with `@pinia/colada@1.2.0`