### PR TITLE
fix: Update ZenStack dependencies to v3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
   "devDependencies": {
     "@pinia/colada": "1.3.1",
     "@types/node": "25.9.1",
-    "@zenstackhq/client-helpers": "3.6.4",
-    "@zenstackhq/common-helpers": "3.6.4",
-    "@zenstackhq/orm": "3.6.4",
-    "@zenstackhq/schema": "3.6.4",
+    "@zenstackhq/client-helpers": "3.7.1",
+    "@zenstackhq/common-helpers": "3.7.1",
+    "@zenstackhq/orm": "3.7.1",
+    "@zenstackhq/schema": "3.7.1",
     "eslint": "10.4.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.5",
@@ -79,5 +79,5 @@
     "pinia": "^3.0.0",
     "vue": "^3.0.0"
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
+  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: 25.9.1
         version: 25.9.1
       '@zenstackhq/client-helpers':
-        specifier: 3.6.4
-        version: 3.6.4(zod@4.1.12)
+        specifier: 3.7.1
+        version: 3.7.1(zod@4.1.12)
       '@zenstackhq/common-helpers':
-        specifier: 3.6.4
-        version: 3.6.4
+        specifier: 3.7.1
+        version: 3.7.1
       '@zenstackhq/orm':
-        specifier: 3.6.4
-        version: 3.6.4(zod@4.1.12)
+        specifier: 3.7.1
+        version: 3.7.1(zod@4.1.12)
       '@zenstackhq/schema':
-        specifier: 3.6.4
-        version: 3.6.4
+        specifier: 3.7.1
+        version: 3.7.1
       eslint:
         specifier: 10.4.0
         version: 10.4.0(jiti@2.6.1)
@@ -787,14 +787,14 @@ packages:
   '@vue/shared@3.5.34':
     resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
-  '@zenstackhq/client-helpers@3.6.4':
-    resolution: {integrity: sha512-ok0IFnVX1YShp/fqDGKtjQo1MaPXnt/X8+4zlVRvbQmf7YP8zkzh/1sH4rr9yOEKdkX8zjyZz1WKNq4TL+Ovxg==}
+  '@zenstackhq/client-helpers@3.7.1':
+    resolution: {integrity: sha512-aeYYA8YK59/RiFUeNMGVB0wMttqJyEgu238Bogv4pVX3jVBm1mfscK2NPxmHPdWed/ZrvthNseRQCFFNINa76A==}
 
-  '@zenstackhq/common-helpers@3.6.4':
-    resolution: {integrity: sha512-s3ZBIrxgF0oXiAMpd/g4+YR1GOFjs7qLvsiGUIxkT8LX1v3j1uuiCooo5NZIwHQaV0oMPZwuQi5/4/hd6CJj2Q==}
+  '@zenstackhq/common-helpers@3.7.1':
+    resolution: {integrity: sha512-EP1Vhc/VFimJ3u97X5IW7eOZ/jWPEIm/9mO8SnpjEFRPnDISCIy9iyfDAXpQ1TmFZzOVucVQulP+5eekha7uUw==}
 
-  '@zenstackhq/orm@3.6.4':
-    resolution: {integrity: sha512-z052oUEepc81fNbaI5yCqy1Z6aMgpzvigUWRZXhuASojKRvaDK+9Kd0x2khqGxM8uIziHwPZu2Xtne9K26imYA==}
+  '@zenstackhq/orm@3.7.1':
+    resolution: {integrity: sha512-G6+d5dhS42ExqcQks5K5aTjA7C/7IfooK0qnf6Sf3kP8Q9NjfbWALYUIveWJNuf2mhFSlvP5yLMiik8A/eqcVw==}
     peerDependencies:
       better-sqlite3: ^12.5.0
       mysql2: ^3.16.1
@@ -811,11 +811,11 @@ packages:
       sql.js:
         optional: true
 
-  '@zenstackhq/schema@3.6.4':
-    resolution: {integrity: sha512-PFRVfL5vrF5gxKM0i78XT+qFxqDE5wrGGiUkFguPyJKsebZQ1JOubUL7oLzES7Eirbm9wo1S/9kNCmkMpoVPcA==}
+  '@zenstackhq/schema@3.7.1':
+    resolution: {integrity: sha512-FhuGrDwZcDyDeVKv18qPHg7RkAxtcDwf6E+Lgu9ekjyF8o2D7Fyrqpg+oREmRPsxdKjXz0Gktx60d6uwmdlvHA==}
 
-  '@zenstackhq/zod@3.6.4':
-    resolution: {integrity: sha512-kzSFMAxKFol3kKmPcl03QBl0USXF86d56Tuv/0Ok28+bpT0ChhsYkFlGQDbVnTHYtD9fsJCa67PVxvfk7NJT/A==}
+  '@zenstackhq/zod@3.7.1':
+    resolution: {integrity: sha512-BsiZbIb2MYbzvPkDYbeX2uR2klncVlRI9bq7/cSFAIMzbvp78Cn7S8RbI4hfd1+iSB5Yy6mTYsmNjdMUYWYRMQ==}
     peerDependencies:
       zod: ^4.0.0
 
@@ -1178,9 +1178,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  kysely@0.28.16:
-    resolution: {integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==}
-    engines: {node: '>=20.0.0'}
+  kysely@0.29.2:
+    resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
+    engines: {node: '>=22.0.0'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2147,11 +2147,11 @@ snapshots:
 
   '@vue/shared@3.5.34': {}
 
-  '@zenstackhq/client-helpers@3.6.4(zod@4.1.12)':
+  '@zenstackhq/client-helpers@3.7.1(zod@4.1.12)':
     dependencies:
-      '@zenstackhq/common-helpers': 3.6.4
-      '@zenstackhq/orm': 3.6.4(zod@4.1.12)
-      '@zenstackhq/schema': 3.6.4
+      '@zenstackhq/common-helpers': 3.7.1
+      '@zenstackhq/orm': 3.7.1(zod@4.1.12)
+      '@zenstackhq/schema': 3.7.1
       decimal.js: 10.6.0
       superjson: 2.2.6
     transitivePeerDependencies:
@@ -2161,18 +2161,18 @@ snapshots:
       - sql.js
       - zod
 
-  '@zenstackhq/common-helpers@3.6.4': {}
+  '@zenstackhq/common-helpers@3.7.1': {}
 
-  '@zenstackhq/orm@3.6.4(zod@4.1.12)':
+  '@zenstackhq/orm@3.7.1(zod@4.1.12)':
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
-      '@zenstackhq/common-helpers': 3.6.4
-      '@zenstackhq/schema': 3.6.4
-      '@zenstackhq/zod': 3.6.4(zod@4.1.12)
+      '@zenstackhq/common-helpers': 3.7.1
+      '@zenstackhq/schema': 3.7.1
+      '@zenstackhq/zod': 3.7.1(zod@4.1.12)
       cuid: 3.0.0
       decimal.js: 10.6.0
       json-stable-stringify: 1.3.0
-      kysely: 0.28.16
+      kysely: 0.29.2
       nanoid: 5.1.6
       postgres-array: 3.0.4
       toposort: 2.0.2
@@ -2182,13 +2182,13 @@ snapshots:
       zod: 4.1.12
       zod-validation-error: 4.0.2(zod@4.1.12)
 
-  '@zenstackhq/schema@3.6.4':
+  '@zenstackhq/schema@3.7.1':
     dependencies:
       decimal.js: 10.6.0
 
-  '@zenstackhq/zod@3.6.4(zod@4.1.12)':
+  '@zenstackhq/zod@3.7.1(zod@4.1.12)':
     dependencies:
-      '@zenstackhq/schema': 3.6.4
+      '@zenstackhq/schema': 3.7.1
       decimal.js: 10.6.0
       zod: 4.1.12
 
@@ -2548,7 +2548,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  kysely@0.28.16: {}
+  kysely@0.29.2: {}
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,1 +1,0 @@
-export const CUSTOM_PROC_ROUTE_NAME = "$procs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,14 +51,13 @@ import { lowerCaseFirst } from "@zenstackhq/common-helpers"
 import {
   createInvalidator,
   createOptimisticUpdater,
-  DEFAULT_QUERY_ENDPOINT,
+  CUSTOM_PROC_ROUTE_NAME,
   type InferOptions,
   type InferSchema,
   type InvalidationPredicate,
 } from "@zenstackhq/client-helpers"
 import { fetcher, makeUrl, marshal } from "@zenstackhq/client-helpers/fetch"
 import { getAllQueries, invalidateQueriesMatchingPredicate } from "./common/client"
-import { CUSTOM_PROC_ROUTE_NAME } from "./common/constants"
 import { getQueryKey } from "./common/query-key"
 import type {
   ExtraMutationOptions,
@@ -82,6 +81,8 @@ export type { SchemaDef } from "@zenstackhq/schema"
  * @see https://github.com/genu/zenstack-pinia-colada/issues/71
  */
 type InferExtResult<T> = T extends ClientContract<infer _S, infer _O, infer _Q, infer _C, infer E> ? E : {}
+
+const DEFAULT_QUERY_ENDPOINT = "/api/model"
 
 export const PiniaColadaContextKey = "zenstack-pinia-colada-context"
 


### PR DESCRIPTION
Updates @zenstackhq/client-helpers, common-helpers, orm, and schema from 3.6.4 to 3.7.1, with the refreshed lockfile and pnpm 11.3.0 package manager metadata.

Adapts the client helper imports for the newer ZenStack API by importing CUSTOM_PROC_ROUTE_NAME from @zenstackhq/client-helpers and keeping DEFAULT_QUERY_ENDPOINT local.

Validation: pnpm test:all and pnpm build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@zenstackhq` development dependencies from version 3.6.4 to 3.7.1
  * Upgraded package manager to pnpm 11.3.0

* **Refactor**
  * Reorganized internal constant sourcing and endpoint configuration across modules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genu/zenstack-pinia-colada/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->